### PR TITLE
Return ring cells in order by using Array<> instead of Set<>

### DIFF
--- a/Sources/HexGrid/HexGrid.swift
+++ b/Sources/HexGrid/HexGrid.swift
@@ -255,18 +255,19 @@ public class HexGrid: Codable {
     ///   - coordinates: `CubeCoordinates`
     ///   - radius: `Int`
     ///   - includingBlocked: optional `Bool`
-    /// - Returns: `Set<CubeCoordinates>`
+    /// - Returns: `Array<CubeCoordinates>`
     /// - Throws: `InvalidArgumentsError` in case underlying cube coordinates initializer propagate the error.
     /// - Note: Coordinates of blocked cells are excluded by default.
     public func ringCoordinates(
         from coordinates: CubeCoordinates,
         in radius: Int,
-        includingBlocked: Bool = false) throws -> Set<CubeCoordinates> {
+        includingBlocked: Bool = false) throws -> [CubeCoordinates] {
         let ring = try Math.ring(from: coordinates, in: radius)
         if includingBlocked {
-            return ring.intersection(self.allCellsCoordinates())
+            return ring.filter({self.allCellsCoordinates().contains($0)})
         }
-        return ring.intersection(self.nonBlockedCellsCoordinates())
+        
+        return ring.filter({self.nonBlockedCellsCoordinates().contains($0)})
     }
     
     /// Search for cells making a ring from origin cell in specified radius
@@ -274,14 +275,14 @@ public class HexGrid: Codable {
     ///   - cell: `Cell`
     ///   - radius: `Int`
     ///   - includingBlocked: optional `Bool`
-    /// - Returns: `Set<Cell>`
+    /// - Returns: `Array<Cell>`
     /// - Throws: `InvalidArgumentsError` in case underlying cube coordinates initializer propagate the error.
     /// - Note: Blocked cells are excluded by default.
-    public func ring(from cell: Cell, in radius: Int, includingBlocked: Bool = false) throws -> Set<Cell> {
-        return Set(try self.ringCoordinates(
+    public func ring(from cell: Cell, in radius: Int, includingBlocked: Bool = false) throws -> [Cell] {
+        return try self.ringCoordinates(
             from: cell.coordinates,
             in: radius,
-            includingBlocked: includingBlocked ).compactMap { self.cellAt($0) })
+            includingBlocked: includingBlocked).compactMap { self.cellAt($0)}
     }
     
     /// Search for coordinates making a filled ring from origin coordinates in specified radius

--- a/Sources/HexGrid/Math.swift
+++ b/Sources/HexGrid/Math.swift
@@ -268,19 +268,19 @@ internal struct Math {
     /// - Parameters:
     ///     - from: coordinates of a ring center
     ///     - in: ring radius
-    /// - Returns: Set of all coordinates making a ring from hex `origin` on `radius`
-    static func ring(from origin: CubeCoordinates, in radius: Int) throws -> Set<CubeCoordinates> {
-        var results = Set<CubeCoordinates>()
+    /// - Returns: Array of all coordinates making a ring from hex `origin` on `radius`
+    static func ring(from origin: CubeCoordinates, in radius: Int) throws -> [CubeCoordinates] {
+        var results = [CubeCoordinates]()
         switch radius {
         case Int.min..<0:
             throw InvalidArgumentsError(message: "Radius can't be less than zero.")
         case 0:
-            results.insert(origin)
+            results.append(origin)
         default:
             var h = try add(a: origin, b: scale(a: direction(at: 4), c: radius))
             for side in 0..<6 {
                 for _ in 0..<radius {
-                    results.insert(h)
+                    results.append(h)
                     h = try neighbor(at: side, origin: h)
                 }
             }

--- a/Tests/HexGridTests/HexGridTests.swift
+++ b/Tests/HexGridTests/HexGridTests.swift
@@ -363,21 +363,21 @@ class HexGridTests: XCTestCase {
             shape: GridShape.hexagon(1))
         grid.cellAt(try CubeCoordinates(x:  1, y:  0, z: -1))?.isBlocked = true
         
-        let testSet: Set<CubeCoordinates> = try [
-            CubeCoordinates(x:  1,  y: -1,  z:  0),
-            CubeCoordinates(x:  0,  y: -1,  z:  1),
-            CubeCoordinates(x: -1,  y:  0,  z:  1),
-            CubeCoordinates(x: -1,  y:  1,  z:  0),
-            CubeCoordinates(x:  0,  y:  1,  z: -1)
+        let testSet: Array<CubeCoordinates> = try [
+            CubeCoordinates(x:  -1,  y: 1,  z:  0),
+            CubeCoordinates(x:  0,  y: 1,  z:  -1),
+            CubeCoordinates(x: 1,  y:  -1,  z:  0),
+            CubeCoordinates(x:  0,  y:  -1,  z: 1),
+            CubeCoordinates(x:  -1,  y:  0,  z: 1)
         ]
         
-        let testSetWithBlocked: Set<CubeCoordinates> = try [
-            CubeCoordinates(x:  1,  y:  0,  z: -1),
-            CubeCoordinates(x:  1,  y: -1,  z:  0),
-            CubeCoordinates(x:  0,  y: -1,  z:  1),
-            CubeCoordinates(x: -1,  y:  0,  z:  1),
-            CubeCoordinates(x: -1,  y:  1,  z:  0),
-            CubeCoordinates(x:  0,  y:  1,  z: -1)
+        let testSetWithBlocked: Array<CubeCoordinates> = try [
+            CubeCoordinates(x:  -1,  y: 1,  z:  0),
+            CubeCoordinates(x:  0,  y: 1,  z:  -1),
+            CubeCoordinates(x: 1,  y:  0,  z:  -1),
+            CubeCoordinates(x: 1,  y:  -1,  z:  0),
+            CubeCoordinates(x:  0,  y:  -1,  z: 1),
+            CubeCoordinates(x:  -1,  y:  0,  z: 1)
         ]
         
         let origin = try CubeCoordinates(x: 0, y: 0, z: 0)
@@ -393,21 +393,22 @@ class HexGridTests: XCTestCase {
             shape: GridShape.hexagon(1))
         grid.cellAt(try CubeCoordinates(x:  1, y:  0, z: -1))?.isBlocked = true
         
-        let testSet: Set<Cell> = try [
-            Cell(CubeCoordinates(x:  1,  y: -1,  z:  0)),
-            Cell(CubeCoordinates(x:  0,  y: -1,  z:  1)),
-            Cell(CubeCoordinates(x: -1,  y:  0,  z:  1)),
-            Cell(CubeCoordinates(x: -1,  y:  1,  z:  0)),
-            Cell(CubeCoordinates(x:  0,  y:  1,  z: -1))
+        let testSet: Array<Cell> = try [
+            Cell(CubeCoordinates(x:  -1,  y: 1,  z:  0)),
+            Cell(CubeCoordinates(x:  0,  y: 1,  z:  -1)),
+            Cell(CubeCoordinates(x: 1,  y:  -1,  z:  0)),
+            Cell(CubeCoordinates(x:  0,  y:  -1,  z: 1)),
+            Cell(CubeCoordinates(x:  -1,  y:  0,  z: 1))
         ]
         
-        let testSetWithBlocked: Set<Cell> = try [
-            Cell(CubeCoordinates(x:  1,  y:  0,  z: -1)),
-            Cell(CubeCoordinates(x:  1,  y: -1,  z:  0)),
-            Cell(CubeCoordinates(x:  0,  y: -1,  z:  1)),
-            Cell(CubeCoordinates(x: -1,  y:  0,  z:  1)),
-            Cell(CubeCoordinates(x: -1,  y:  1,  z:  0)),
-            Cell(CubeCoordinates(x:  0,  y:  1,  z: -1))
+        let testSetWithBlocked: Array<Cell> = try [
+            Cell(CubeCoordinates(x:  -1,  y: 1,  z:  0)),
+            Cell(CubeCoordinates(x:  0,  y: 1,  z:  -1)),
+            Cell(CubeCoordinates(x:  1,  y: 0,  z:  -1)),
+            Cell(CubeCoordinates(x: 1,  y:  -1,  z:  0)),
+            Cell(CubeCoordinates(x:  0,  y:  -1,  z: 1)),
+            Cell(CubeCoordinates(x:  -1,  y:  0,  z: 1))
+
         ]
         
         if let originCell = try grid.cellAt(CubeCoordinates(x: 0, y: 0, z: 0)) {

--- a/Tests/HexGridTests/MathTests.swift
+++ b/Tests/HexGridTests/MathTests.swift
@@ -179,13 +179,13 @@ class MathTests: XCTestCase {
     /// Test ring
     func testRing() throws {
         let ring = try Math.ring(from: CubeCoordinates(x: 1, y: -1, z: 0), in: 1)
-        let testSet: Set<CubeCoordinates> = try [
-            CubeCoordinates(x:  0,  y: -1,  z:  1),
-            CubeCoordinates(x:  0,  y:  0,  z:  0),
-            CubeCoordinates(x:  1,  y:  0,  z: -1),
-            CubeCoordinates(x:  2,  y: -1,  z: -1),
-            CubeCoordinates(x:  2,  y: -2,  z:  0),
-            CubeCoordinates(x:  1,  y: -2,  z:  1)
+        let testSet: [CubeCoordinates] = try [
+            CubeCoordinates(x:  0,  y: 0,  z:  0),
+            CubeCoordinates(x:  1,  y:  0,  z:  -1),
+            CubeCoordinates(x:  2,  y:  -1,  z: -1),
+            CubeCoordinates(x:  2,  y: -2,  z: 0),
+            CubeCoordinates(x:  1,  y: -2,  z:  1),
+            CubeCoordinates(x:  0,  y: -1,  z:  1)
             ]
         XCTAssertEqual(ring, testSet)
     }
@@ -193,7 +193,7 @@ class MathTests: XCTestCase {
     /// Test zero ring
     func testZeroRing() throws {
         let ring = try Math.ring(from: CubeCoordinates(x: 1, y: -1, z: 0), in: 0)
-        let testSet: Set<CubeCoordinates> = try [
+        let testSet: Array<CubeCoordinates> = try [
             CubeCoordinates(x: 1, y: -1, z: 0),
         ]
         XCTAssertEqual(ring, testSet)
@@ -203,7 +203,7 @@ class MathTests: XCTestCase {
     func testInvalidRing() throws {
         XCTAssertThrowsError(try Math.ring(from: CubeCoordinates(x: 1, y: -1, z: 0), in: -1))
     }
-    
+        
     /// Test filled ring
     func testFilledRing() throws {
         let filledRing = try Math.filledRing(from: CubeCoordinates(x: 0, y: 0, z: 0), in: 1)


### PR DESCRIPTION
Preserves the order of the cells in the ring allowing it to be used for traversing the ring cells in order.