### PR TITLE
Hex Centre Point logic bug fix

### DIFF
--- a/Sources/HexGrid/Cell.swift
+++ b/Sources/HexGrid/Cell.swift
@@ -32,7 +32,7 @@ public class Cell: Codable {
         }
     }
 
-    /// Manhatan distance to coordinates
+    /// Manhattan distance to coordinates
     ///
     /// - parameters:
     ///   - coordinates: Target coordinates
@@ -42,7 +42,7 @@ public class Cell: Codable {
         return try Math.distance(from: self.coordinates, to: coordinates)
     }
 
-    /// Manhatan distance to cell
+    /// Manhattan distance to cell
     ///
     /// - parameters:
     ///   - cell: Target cell

--- a/Sources/HexGrid/Convertor.swift
+++ b/Sources/HexGrid/Convertor.swift
@@ -77,8 +77,8 @@ internal struct Convertor {
         orientation: Orientation) -> Point {
         let axialCoords = coordinates.toAxial()
         let orientation = OrientationMatrix(orientation: orientation)
-        let x = ((orientation.f00 * Double(axialCoords.q)) + (orientation.f10 * Double(axialCoords.r))) * hexSize.width
-        let y = ((orientation.f01 * Double(axialCoords.q)) + (orientation.f11 * Double(axialCoords.r))) * hexSize.height
+        let x = ((orientation.f00 * Double(axialCoords.q)) + (orientation.f10 * Double(axialCoords.r))) * (hexSize.width/2)
+        let y = ((orientation.f01 * Double(axialCoords.q)) + (orientation.f11 * Double(axialCoords.r))) * (hexSize.height/2)
 
         return Point(x: x + gridOrigin.x, y: y + gridOrigin.y)
     }

--- a/Sources/HexGrid/DataStructures/Heap.swift
+++ b/Sources/HexGrid/DataStructures/Heap.swift
@@ -190,7 +190,7 @@ internal struct Heap<T> {
     
     /**
      * Looks at a parent node and makes sure it is still larger (max-heap) or
-     * smaller (min-heap) than its childeren.
+     * smaller (min-heap) than its children.
      */
     internal mutating func shiftDown(from index: Int, until endIndex: Int) {
         let leftChildIndex = self.leftChildIndex(ofIndex: index)

--- a/Sources/HexGrid/Generator.swift
+++ b/Sources/HexGrid/Generator.swift
@@ -61,7 +61,7 @@ internal struct Generator {
     
     /// Create grid of hexagonal shape
     /// - parameters:
-    ///     - radius: radius of desired hexagonal shape (0 -> sinlge tile, 1 -> 7 tiles, 2 -> 19 tiles...)
+    ///     - radius: radius of desired hexagonal shape (0 -> single tile, 1 -> 7 tiles, 2 -> 19 tiles...)
     static func createHexagonGrid (
         radius: Int
         ) throws -> Set<CubeCoordinates> {

--- a/Sources/HexGrid/HexGrid.swift
+++ b/Sources/HexGrid/HexGrid.swift
@@ -1,6 +1,6 @@
 /// HexGrid is an entry point of the package. It represents a grid of hexagonal cells
 public class HexGrid: Codable {
-    public var orientaion: Orientation
+    public var orientation: Orientation
     public var offsetLayout: OffsetLayout
     public var hexSize: HexSize
     public var origin: Point
@@ -29,7 +29,7 @@ public class HexGrid: Codable {
         origin: Point = Point(x: 0, y: 0),
         attributes: [String: Attribute] = [String: Attribute]()) {
         self.cells = cells
-        self.orientaion = orientation
+        self.orientation = orientation
         self.offsetLayout = offsetLayout
         self.hexSize = hexSize
         self.origin = origin
@@ -51,7 +51,7 @@ public class HexGrid: Codable {
         hexSize: HexSize = HexSize(width: 10.0, height: 10.0),
         origin: Point = Point(x: 0, y: 0),
         attributes: [String: Attribute] = [String: Attribute]()) {
-        self.orientaion = orientation
+        self.orientation = orientation
         self.offsetLayout = offsetLayout
         self.hexSize = hexSize
         self.origin = origin
@@ -318,7 +318,7 @@ public class HexGrid: Codable {
     
     // MARK: Grid searching (flood search and pathfinding)
     
-    /// Search for all coordinates reachanble from origin coordinates within specified number of steps
+    /// Search for all coordinates reachable from origin coordinates within specified number of steps
     /// - Parameters:
     ///   - coordinates: `CubeCoordinates` origin
     ///   - steps: maximum number of steps
@@ -329,7 +329,7 @@ public class HexGrid: Codable {
         return try Math.breadthFirstSearch(from: coordinates, in: steps, on: self)
     }
     
-    /// Search for all cells reachanble from origin cell within specified number of steps
+    /// Search for all cells reachable from origin cell within specified number of steps
     /// - Parameters:
     ///   - cell: `Cell` origin
     ///   - steps: maximum number of steps
@@ -342,7 +342,7 @@ public class HexGrid: Codable {
             in: steps).compactMap{ self.cellAt($0) })
     }
     
-    /// Search for the sortest path from origin to target coordinates
+    /// Search for the shortest path from origin to target coordinates
     /// - Parameters:
     ///   - origin: `CubeCoordinates` starting position
     ///   - target: `CubeCoordinates` target position
@@ -353,7 +353,7 @@ public class HexGrid: Codable {
         return try Math.aStarPath(from: origin, to: target, on: self)
     }
     
-    /// Search for the sortest path from origin to target cell
+    /// Search for the shortest path from origin to target cell
     /// - Parameters:
     ///   - origin: `Cell` starting position
     ///   - target: `Cell` target position
@@ -378,7 +378,7 @@ public class HexGrid: Codable {
             coordinates: cell.coordinates,
             hexSize: self.hexSize,
             origin: self.origin,
-            orientation: self.orientaion)
+            orientation: self.orientation)
     }
     
     /// Calculate screen coordinates for center of a hexagon
@@ -386,7 +386,7 @@ public class HexGrid: Codable {
     /// - Returns: `Point` (x, y - screen coordinates) of a cell center
     /// - Note: This function take into account grid orientation as well as its origin screen coordinates.
     public func pixelCoordinates(for cell: Cell) -> Point {
-        return cell.coordinates.toPixel(orientation: self.orientaion, hexSize: self.hexSize, origin: self.origin)
+        return cell.coordinates.toPixel(orientation: self.orientation, hexSize: self.hexSize, origin: self.origin)
     }
     
     /// Get cell for specified screen coordinates
@@ -398,12 +398,12 @@ public class HexGrid: Codable {
             from: pixelCoordinates,
             hexSize: self.hexSize,
             origin: self.origin,
-            orientation: self.orientaion)
+            orientation: self.orientation)
         return cellAt(coords)
     }
     
     // MARK: Internal functions
-    /// Function keeps grid dimenstions udpated using property observer
+    /// Function keeps grid dimensions updated using property observer
     fileprivate func updatePixelDimensions() -> Void {
         var minX: Double = 0.0
         var maxX: Double = 0.0
@@ -419,7 +419,7 @@ public class HexGrid: Codable {
         }
         var cellPixelWidth: Double
         var cellPixelHeight: Double
-        switch orientaion {
+        switch orientation {
         case .pointyOnTop:
             cellPixelWidth = (3.0).squareRoot() * hexSize.width
             cellPixelHeight = 2.0 * hexSize.height

--- a/Sources/HexGrid/Math.swift
+++ b/Sources/HexGrid/Math.swift
@@ -80,7 +80,7 @@ internal struct Math {
     /// This formula `(6 + (index % 6)) % 6` make it work with index outside of 0...5.
     /// Works also with negative numbers.
     ///
-    /// This makes `directions`  a closed loop. When an index overflow the array boundry it continues on the other side.
+    /// This makes `directions`  a closed loop. When an index overflow the array boundary it continues on the other side.
     ///
     /// examples:
     ///
@@ -98,7 +98,7 @@ internal struct Math {
     /// - Parameters:
     ///     - at: index of desired direction (0...5).
     ///     - origin: Coordinates of the origin hexagon.
-    /// - Returns: Coordinates of a neighnor at specified direction
+    /// - Returns: Coordinates of a neighbor at specified direction
     /// - Throws: `InvalidArgumentsError` in case underlying cube coordinates initializer propagate the error.
     static func neighbor(at index: Int, origin: CubeCoordinates) throws -> CubeCoordinates {
         return try add(a: origin, b: direction(at: index))
@@ -136,7 +136,7 @@ internal struct Math {
     /// - Note:
     /// This formula `(6 + (index % 6)) % 6` make it work with index outside of 0...5. Works also with negative numbers.
     ///
-    /// This makes `diagonalDirections` a closed loop. When index overflow an array boundry it continues on the other side.
+    /// This makes `diagonalDirections` a closed loop. When index overflow an array boundary it continues on the other side.
     ///
     /// examples:
     ///
@@ -147,7 +147,7 @@ internal struct Math {
     ///   index `13` will return the same direction as index `1`
     static func diagonalDirection(at index: Int) -> CubeCoordinates {
         // This ugly formula make it work with index outside of 0...5
-        // It's usefull for negative numbers (e.g. backward rotation)
+        // It's useful for negative numbers (e.g. backward rotation)
         return diagonalDirections[(6 + (index % 6)) % 6]
     }
     
@@ -156,7 +156,7 @@ internal struct Math {
     /// - Parameters:
     ///     - at: index of desired direction (0...5).
     ///     - origin: Coordinates of the origin hexagon.
-    /// - Returns: Coordinates of a diagonal neighnor at specified direction
+    /// - Returns: Coordinates of a diagonal neighbor at specified direction
     /// - Throws: `InvalidArgumentsError` in case underlying cube coordinates initializer propagate the error.
     static func diagonalNeighbor(at index: Int, origin: CubeCoordinates) throws -> CubeCoordinates {
         return try add(a: origin, b: diagonalDirection(at: index))
@@ -210,7 +210,7 @@ internal struct Math {
     /// - Parameters:
     ///     - coordinates: coordinates of a hex
     ///     - hexSize: represents display height and width of a hex
-    ///     - gridOrigin: dispaly coordinates of a grid origin
+    ///     - gridOrigin: display coordinates of a grid origin
     ///     - orientation: orientation of a grid
     /// - Returns: Array of six display coordinates (polygon vertices).
     static func hexCorners(
@@ -244,7 +244,7 @@ internal struct Math {
     /// Line between two hexes
     /// - Parameters:
     ///     - from: origin coordinates
-    ///     - to: target coodrinates
+    ///     - to: target coordinates
     /// - Returns: Set of all coordinates making a line from coordinate `a` to coordinate `b`
     static func line(from a: CubeCoordinates, to b: CubeCoordinates) throws -> Set<CubeCoordinates> {
         let n = try distance(from: a, to: b)

--- a/Tests/HexGridTests/CoordinatesTests.swift
+++ b/Tests/HexGridTests/CoordinatesTests.swift
@@ -111,8 +111,8 @@ class CoordinatesTests: XCTestCase {
             orientation: Orientation.pointyOnTop,
             hexSize: HexSize(width: 10.0, height: 10.0),
             origin: Point(x: 0.0, y: 0.0))
-        XCTAssertEqual(pixelCoordinates.x, 25.98076211353316)
-        XCTAssertEqual(pixelCoordinates.y, -15.0)
+        XCTAssertEqual(pixelCoordinates.x, 12.99038105676658)
+        XCTAssertEqual(pixelCoordinates.y, -7.5)
     }
     
     /// Convert coordinates from cube to offset using `pointy on top` orientation and `odd` offset layout

--- a/Tests/HexGridTests/HexGridTests.swift
+++ b/Tests/HexGridTests/HexGridTests.swift
@@ -644,7 +644,7 @@ class HexGridTests: XCTestCase {
             origin: gridOrigin)
         let cell = try Cell(CubeCoordinates(x: 1, y: -1, z: 0))
         let center = gridPointy.pixelCoordinates(for: cell)
-        let expectedCenter = Point(x: 17.32050807568877, y: 0.0)
+        let expectedCenter = Point(x: 8.660254037844386, y: 0.0)
         XCTAssertEqual(center, expectedCenter)
     }
     
@@ -677,10 +677,10 @@ class HexGridTests: XCTestCase {
             offsetLayout: OffsetLayout.even,
             hexSize: hexSize,
             origin: gridOrigin)
-        let expectedWidthPonity: Double = 86.6
-        let expectedHeightPonity: Double = 80.0
-        XCTAssertEqual((gridPointy.pixelWidth * 10).rounded()/10, expectedWidthPonity)
-        XCTAssertEqual(gridPointy.pixelHeight, expectedHeightPonity)
+        let expectedWidthPointy: Double = 52.0
+        let expectedHeightPointy: Double = 50.0
+        XCTAssertEqual((gridPointy.pixelWidth * 10).rounded()/10, expectedWidthPointy)
+        XCTAssertEqual(gridPointy.pixelHeight, expectedHeightPointy)
         
         let gridFlat = HexGrid(
             shape: GridShape.hexagon(2),
@@ -688,8 +688,8 @@ class HexGridTests: XCTestCase {
             offsetLayout: OffsetLayout.even,
             hexSize: hexSize,
             origin: gridOrigin)
-        let expectedWidthFlat: Double = 80.0
-        let expectedHeightFlat: Double = 86.6
+        let expectedWidthFlat: Double = 50.0
+        let expectedHeightFlat: Double = 52.0
         XCTAssertEqual(gridFlat.pixelWidth, expectedWidthFlat)
         XCTAssertEqual((gridFlat.pixelHeight * 10).rounded()/10, expectedHeightFlat)
     }


### PR DESCRIPTION
I've been using your library to build a SpriteKit game.  Firstly, thanks heaps for implementing the hex math content that Red Blob Games have posted.  I really appreciate it!

I have found a fixed a small bug with the calculation for determining the centre point of a cell.
As I was laying out hexes onto a screen, I found that the centre point of each rendered hex was twice the value I expected.  You can see from the attached files the difference in rendering.

I also took the opportunity to fix a few typos :)

Thanks again!

Before:
<img width="964" alt="before" src="https://user-images.githubusercontent.com/574865/82200603-51af4e00-9953-11ea-9d4c-b3a99e9fb0fe.png">

After:
<img width="964" alt="after" src="https://user-images.githubusercontent.com/574865/82200691-7277a380-9953-11ea-953c-fca97c5e3f9e.png">

