### PR TITLE
Added doccomments to HexGrid properties and various structures and enumerations. Encapsulated pixelWidth and pixelHeight properties into a HexSize structure.

### DIFF
--- a/Sources/HexGrid/DataStructures/HexSize.swift
+++ b/Sources/HexGrid/DataStructures/HexSize.swift
@@ -1,4 +1,5 @@
-public struct HexSize: Codable {
+/// Basic structure holding a `width` and `height`.
+public struct HexSize: Codable, Equatable {
     public var width, height: Double
 
     /// Width and Height of a hex

--- a/Sources/HexGrid/DataStructures/Point.swift
+++ b/Sources/HexGrid/DataStructures/Point.swift
@@ -1,14 +1,13 @@
-public struct Point: Codable {
+/// Basic structure containing an `x` and `y` value.
+public struct Point: Codable, Equatable {
     public var x, y: Double
 
+    /// Initializing the `Point`.
+    /// - Parameters:
+    ///   - x: horizontal coordinate value
+    ///   - y: vertical coordinate value
     public init (x: Double, y: Double) {
         self.x = x
         self.y = y
-    }
-}
-
-extension Point: Equatable {
-    public static func ==(lhs: Point, rhs: Point) -> Bool {
-        return lhs.x.isEqual(to: rhs.x) && lhs.y.isEqual(to: rhs.y)
     }
 }

--- a/Sources/HexGrid/Enumerations/GridShapeEnumeration.swift
+++ b/Sources/HexGrid/Enumerations/GridShapeEnumeration.swift
@@ -1,10 +1,15 @@
-/// Enumeration for hexagonal grid shapes
-
+/// Enumeration for built-in types of hexagonal grid shapes.
+///
+/// Options are: `hexagon`, `rectangle`, and `triangle`.
+/// Each option has stored properties relevant to that shape.
 public enum GridShape {
-    /// width, height
-    case rectangle(Int, Int)
-    /// radius
+
+    /// Hexagonal `GridShape`. Stored property corresponds to side-length.
     case hexagon(Int)
-    /// side size
+
+    /// Rectangular `GridShape`. Stored properties are for width and height.
+    case rectangle(Int, Int)
+
+    /// Triangular `GridShape`. Stored property is side-length.
     case triangle(Int)
 }

--- a/Sources/HexGrid/Enumerations/OrientationEnumeration.swift
+++ b/Sources/HexGrid/Enumerations/OrientationEnumeration.swift
@@ -1,5 +1,5 @@
 /// Enumeration for hexagon orientation
-
+/// Options are either `pointyOnTop` or `flatOnTop`.
 public enum Orientation: String, Codable {
     /// ⬢ - pointy side on top of a hexagon
     case pointyOnTop

--- a/Sources/HexGrid/HexGrid.swift
+++ b/Sources/HexGrid/HexGrid.swift
@@ -1,18 +1,41 @@
 /// HexGrid is an entry point of the package. It represents a grid of hexagonal cells
 public class HexGrid: Codable {
+    /// The `Orientation` of all the hexagons in the grid.
     public var orientation: Orientation
+
+    /// The `OffsetLayout` option for the grid.
     public var offsetLayout: OffsetLayout
-    public var hexSize: HexSize
+
+    /// A bounding size for each individual hexagon cell in the grid.
+    /// Note that for regular hexagons, `hexSize` should be square,
+    /// (`width` and `height` values the same), and the
+    /// hexagon itself will be drawn slightly inset inside this box.
+    /// (Which direction depends on the grid's `orientation`.)
+    public var hexSize: HexSize {
+        didSet {
+            if hexSize != oldValue {
+                updatePixelDimensions()
+            }
+        }
+    }
+
+    /// The point of origin for generating pixel coordinates and various drawing-related values.
     public var origin: Point
+
+    /// All the cells in the grid.
     public var cells: Set<Cell> {
         didSet {
             updatePixelDimensions()
         }
     }
+
+    /// User attributes stored on the grid itself.
     public var attributes: [String: Attribute]
-    private(set) public var pixelWidth: Double = 0
-    private(set) public var pixelHeight: Double = 0
-    
+
+    /// Width and height of the entire grid in pixel dimensions.
+    /// - Note: This value is calculated at based on the `hexSize` property.
+    private(set) public var pixelSize = HexSize(width: 0.0, height: 0.0)
+
     // MARK: Initializers
     /// Default initializer
     /// - Parameters:
@@ -445,8 +468,9 @@ public class HexGrid: Codable {
             orientation: self.orientation)
         return cellAt(coords)
     }
-    
+
     // MARK: Internal functions
+
     /// Function keeps grid dimensions updated using property observer
     fileprivate func updatePixelDimensions() -> Void {
         var minX: Double = 0.0
@@ -471,7 +495,7 @@ public class HexGrid: Codable {
             cellPixelWidth = 2.0 * hexSize.width
             cellPixelHeight = (3.0).squareRoot() * hexSize.height
         }
-        pixelWidth = (maxX - minX) + cellPixelWidth
-        pixelHeight = (maxY - minY) + cellPixelHeight
+        pixelSize.width = (maxX - minX) + cellPixelWidth
+        pixelSize.height = (maxY - minY) + cellPixelHeight
     }
 }

--- a/Tests/HexGridTests/HexGridTests.swift
+++ b/Tests/HexGridTests/HexGridTests.swift
@@ -815,8 +815,8 @@ class HexGridTests: XCTestCase {
             origin: gridOrigin)
         let expectedWidthPointy: Double = 86.6
         let expectedHeightPointy: Double = 80.0
-        XCTAssertEqual((gridPointy.pixelWidth * 10).rounded()/10, expectedWidthPointy)
-        XCTAssertEqual(gridPointy.pixelHeight, expectedHeightPointy)
+        XCTAssertEqual((gridPointy.pixelSize.width * 10).rounded()/10, expectedWidthPointy)
+        XCTAssertEqual(gridPointy.pixelSize.height, expectedHeightPointy)
         
         let gridFlat = HexGrid(
             shape: GridShape.hexagon(3),
@@ -826,8 +826,8 @@ class HexGridTests: XCTestCase {
             origin: gridOrigin)
         let expectedWidthFlat: Double = 80.0
         let expectedHeightFlat: Double = 86.6
-        XCTAssertEqual(gridFlat.pixelWidth, expectedWidthFlat)
-        XCTAssertEqual((gridFlat.pixelHeight * 10).rounded()/10, expectedHeightFlat)
+        XCTAssertEqual(gridFlat.pixelSize.width, expectedWidthFlat)
+        XCTAssertEqual((gridFlat.pixelSize.height * 10).rounded()/10, expectedHeightFlat)
     }
         
     static var allTests = [


### PR DESCRIPTION
Mostly this just includes additional doccomments, but there are two "actual" changes here:

  1. I removed `pixelWidth` and `pixelHeight` in favor of a new `pixelSize`.
  2. I added a new `didSet` to the `hexSize` property to call `updatePixelDomensions()`, because otherwise the pixel values were outdated at that time.

I didn't write any new tests, but I did update them to refer to the `pixelSize` property.

Note that the first change above is a breaking API change, and you'll have to update any code that relies on those properties.
