### PR TITLE
New initializer for drawing the grid in a specific size

### DIFF
--- a/Sources/HexGrid/Generator.swift
+++ b/Sources/HexGrid/Generator.swift
@@ -1,6 +1,33 @@
 /// Generates grid based on parameters
 internal struct Generator {
-    
+
+    /// A Set of `Cell`s based on `GridShape`, `Orientation`, and `OffsetLayout`.
+    /// - parameters:
+    ///    - shape: The `GridShape` for our `Cell` values.
+    ///    - orientation: An `Orientation` value for the generated set of `Cell` values.
+    ///    - offsetLayout: The `OffsetLayout` for the generated set of `Cell`s.
+    /// - returns: A `Set<Cell>`, suitable for use in `HexGrid`.
+    static func cellsForGridShape(
+        shape: GridShape,
+        orientation: Orientation,
+        offsetLayout: OffsetLayout
+    ) throws -> Set<Cell> {
+        switch shape {
+        case .hexagon(let sideLength):
+            return try Set(Generator.createHexagonGrid(sideLength: sideLength).map { Cell($0) })
+        case .rectangle(let width, let height):
+            return try Set(Generator.createRectangleGrid(
+                orientation: orientation,
+                offsetLayout: offsetLayout,
+                width: width,
+                height: height).map { Cell($0) })
+        case .triangle(let sideSize):
+            return try Set(Generator.createTriangleGrid(
+                orientation: orientation,
+                sideLength: sideSize).map { Cell($0) })
+        }
+    }
+
     /// Create grid of rectangular shape
     /// - parameters:
     ///     - orientation: See `OrientationEnumeration` options

--- a/Sources/HexGrid/HexGrid.swift
+++ b/Sources/HexGrid/HexGrid.swift
@@ -9,18 +9,12 @@ public class HexGrid: Codable {
     /// The `OffsetLayout` option for the grid.
     public var offsetLayout: OffsetLayout
 
-    /// A bounding size for each individual hexagon cell in the grid.
-    /// Note that for regular hexagons, `hexSize` should be square,
-    /// (`width` and `height` values the same), and the
-    /// hexagon itself will be drawn slightly inset inside this box.
-    /// (Which direction depends on the grid's `orientation`.)
-    public var hexSize: HexSize {
-        didSet {
-            if hexSize != oldValue {
-                updatePixelDimensions()
-            }
-        }
-    }
+    /// A radius size for each individual hexagon cell in the grid. This describes
+    /// the center of the hexagon to one of its points.
+    /// - Note For regular hexagons, `hexSize` should be a square, meaning
+    /// the `width` and `height` values are the same. Changing one of these values
+    /// to be out of sync with the other will result in hexagons that are "squished".
+    private(set) public var hexSize: HexSize
 
     /// The point of origin for generating pixel coordinates and various drawing-related values.
     public var origin: Point
@@ -105,15 +99,15 @@ public class HexGrid: Codable {
     /// Each hexagon in the grid will "fit" within that size by default.
     /// - Parameters:
     ///   - shape: Shape to be generated
+    ///   - pixelSize: A `HexSize` corresponding to the size for the entire grid.
     ///   - orientation: Grid `Orientation` enumeration
     ///   - offsetLayout: `OffsetLayout` enumeration (used to specify row or column offset for rectangular grids)
-    ///   - pixelSize: A `HexSize` corresponding to the size for the entire grid.
     ///   - attributes: A dictionary of attributes for the entire grid.
     public init(
         shape: GridShape,
+        pixelSize: HexSize,
         orientation: Orientation = Orientation.pointyOnTop,
         offsetLayout: OffsetLayout = OffsetLayout.even,
-        pixelSize: HexSize = HexSize(width: 100.0, height: 100.0),
         attributes: [String: Attribute] = [String: Attribute]()
     ) {
         self.orientation = orientation
@@ -527,16 +521,16 @@ public class HexGrid: Codable {
             newHexSize.width = hexSize.width * heightRatio
         }
         pixelSize = newGridSize
-        hexSize = newHexSize
+        self.hexSize = newHexSize
         setOriginToFitPixelSize(offset: difference)
     }
 
     /// Set the origin to the middle of the grid.
     public func setOriginToFitPixelSize(offset: HexSize) {
-        var minX: Double = 0.0
-        var maxX: Double = 0.0
-        var minY: Double = 0.0
-        var maxY: Double = 0.0
+        var minX: Double = .greatestFiniteMagnitude
+        var maxX: Double = -.greatestFiniteMagnitude
+        var minY: Double = .greatestFiniteMagnitude
+        var maxY: Double = -.greatestFiniteMagnitude
 
         for cell in cells {
             let pixelCoords = pixelCoordinates(for: cell)
@@ -567,10 +561,10 @@ public class HexGrid: Codable {
 
     /// Function keeps grid dimensions updated using property observer
     fileprivate func updatePixelDimensions() -> Void {
-        var minX: Double = 0.0
-        var maxX: Double = 0.0
-        var minY: Double = 0.0
-        var maxY: Double = 0.0
+        var minX: Double = .greatestFiniteMagnitude
+        var maxX: Double = -.greatestFiniteMagnitude
+        var minY: Double = .greatestFiniteMagnitude
+        var maxY: Double = -.greatestFiniteMagnitude
         
         for cell in cells {
             let pixelCoords = pixelCoordinates(for: cell)

--- a/Tests/HexGridTests/HexGridTests.swift
+++ b/Tests/HexGridTests/HexGridTests.swift
@@ -803,6 +803,56 @@ class HexGridTests: XCTestCase {
         }
     }
     
+    /// Test fitGrid
+    func testFitGrid() throws {
+        var gridSize = HexSize(width: 150.0, height: 150)
+        // pointy
+        var grid = HexGrid(
+            shape: GridShape.hexagon(2),
+            pixelSize: gridSize
+        )
+        XCTAssertEqual(grid.pixelSize.width, 150.0, accuracy: 1.0)
+        XCTAssertEqual(grid.pixelSize.height, 144.337, accuracy: 1.0)
+        XCTAssertEqual(grid.hexSize.width, 28.8, accuracy: 1.0)
+        XCTAssertEqual(grid.hexSize.height, 28.8, accuracy: 1.0)
+        XCTAssertEqual(grid.origin.x, 75.0, accuracy: 1.0)
+        XCTAssertEqual(grid.origin.y, 75.0, accuracy: 1.0)
+
+        // flat
+        grid = HexGrid(
+            shape: GridShape.hexagon(2),
+            pixelSize: gridSize,
+            orientation: .flatOnTop
+        )
+        XCTAssertEqual(grid.pixelSize.width, 144, accuracy: 1.0)
+        XCTAssertEqual(grid.pixelSize.height, 150, accuracy: 1.0)
+
+        gridSize = HexSize(width: 2000.0, height: 2000)
+        grid = HexGrid(
+            shape: GridShape.triangle(10),
+            pixelSize: gridSize
+        )
+        XCTAssertEqual(grid.pixelSize.width, 2000, accuracy: 1.0)
+        XCTAssertEqual(grid.pixelSize.height, 1789, accuracy: 1.0)
+        XCTAssertEqual(grid.hexSize.width, 115, accuracy: 1.0)
+        XCTAssertEqual(grid.hexSize.height, 115, accuracy: 1.0)
+        XCTAssertEqual(grid.origin.x, 1000, accuracy: 1.0)
+        XCTAssertEqual(grid.origin.y, 1779, accuracy: 1.0)
+
+        gridSize = HexSize(width: 2000.0, height: 2000)
+        grid = HexGrid(
+            shape: GridShape.triangle(10),
+            pixelSize: gridSize,
+            orientation: .flatOnTop
+        )
+        XCTAssertEqual(grid.pixelSize.width, 1789, accuracy: 1.0)
+        XCTAssertEqual(grid.pixelSize.height, 2000, accuracy: 1.0)
+        XCTAssertEqual(grid.hexSize.width, 115, accuracy: 1.0)
+        XCTAssertEqual(grid.hexSize.height, 115, accuracy: 1.0)
+        XCTAssertEqual(grid.origin.x, 220, accuracy: 1.0)
+        XCTAssertEqual(grid.origin.y, 2799, accuracy: 1.0)
+    }
+
     // Test grid pixel dimensions
     func testGridPixelDimensions() throws {
         let hexSize = HexSize(width: 10.0, height: 10.0)
@@ -860,6 +910,7 @@ class HexGridTests: XCTestCase {
         ("Test calculation of polygon corners", testPolygonCorners),
         ("Test calculation cell pixel coordinates", testPixelCoordinates),
         ("Test get cell for pixel coordinates", testCellAtPixel),
+        ("Test fit grid", testFitGrid),
         ("Test grid pixel dimensions", testGridPixelDimensions)
     ]
 }


### PR DESCRIPTION
- moved grid cell generation code to a static function on the Generator struct. 
- Added initializer and relevant functions to fit the HexGrid into a HexSize.

[Edited to remove commit message from already merged commit.]
