### PR TITLE
more shape generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,11 +342,15 @@ There are four offset types depending on orientation of hexagons. The “row” 
 
 ##### GridShape
 
+Cases from this enumeration can be passed into the `HexGrid` constructor to generate grids of various shapes and sizes.
+
 Options:
 
-- `rectangle(Int, Int)` - rectangle width and height
-- `hexagon(Int)` - radius of hexagon
-- `triangle(Int)` - size of triangle side
+- `rectangle(Int, Int)` - Associated values are column width and row height of the generated grid. Sides of the grid will be essentially parallel to the edges of the screen.
+- `parallelogram(Int, Int)` - Associated values are both side-lengths.
+- `hexagon(Int)` - This generates a regular hexagon shaped grid, with all sides the length of the associated value.
+- `irregularHexagon(Int, Int)` - This is used to generate a grid shaped like a hexagon where every other side is the length of the associated values.
+- `triangle(Int)` - Generates an equilateral triangle with all sides the length of the associated value.
 
 ##### Rotation
 

--- a/Sources/HexGrid/Enumerations/GridShapeEnumeration.swift
+++ b/Sources/HexGrid/Enumerations/GridShapeEnumeration.swift
@@ -7,6 +7,10 @@ public enum GridShape {
     /// Hexagonal `GridShape`. Stored property corresponds to side-length.
     case hexagon(Int)
 
+    /// Irregular hexagon `GridShape`. Stored properties correspond to side-lengths.
+    /// Note that if the side lengths are the same, this falls back to the default hexagon shape.
+    case irregularHexagon(Int, Int)
+
     /// Rectangular `GridShape` that does not attempt to be square. Stored properties are for width and height.
     case parallelogram(Int, Int)
 

--- a/Sources/HexGrid/Enumerations/GridShapeEnumeration.swift
+++ b/Sources/HexGrid/Enumerations/GridShapeEnumeration.swift
@@ -7,7 +7,10 @@ public enum GridShape {
     /// Hexagonal `GridShape`. Stored property corresponds to side-length.
     case hexagon(Int)
 
-    /// Rectangular `GridShape`. Stored properties are for width and height.
+    /// Rectangular `GridShape` that does not attempt to be square. Stored properties are for width and height.
+    case parallelogram(Int, Int)
+
+    /// Rectangular `GridShape` that attempts to create a more or less square shape. Stored properties are for width and height.
     case rectangle(Int, Int)
 
     /// Triangular `GridShape`. Stored property is side-length.

--- a/Sources/HexGrid/Generator.swift
+++ b/Sources/HexGrid/Generator.swift
@@ -15,6 +15,10 @@ internal struct Generator {
         switch shape {
         case .hexagon(let sideLength):
             return try Set(Generator.createHexagonGrid(sideLength: sideLength).map { Cell($0) })
+        case .parallelogram(let width, let height):
+            return try Set(Generator.createParallelogramGrid(
+                width: width,
+                height: height).map { Cell($0) })
         case .rectangle(let width, let height):
             return try Set(Generator.createRectangleGrid(
                 orientation: orientation,
@@ -28,17 +32,38 @@ internal struct Generator {
         }
     }
 
-    /// Create grid of rectangular shape
+    /// Create grid of rectangular (parallelogram) shape
+    /// - parameters:
+    ///     - width: number of columns
+    ///     - height: number of rows
+    static func createParallelogramGrid(
+        width: Int,
+        height: Int
+    ) throws -> Set<CubeCoordinates> {
+        guard width > 0, height > 0 else {
+            throw InvalidArgumentsError(message: "Rectangle width and height must be greater than zero.")
+        }
+        var tiles = Set<CubeCoordinates>()
+        for row in 0..<height {
+            for column in 0..<width {
+                tiles.insert(try AxialCoordinates(q: row, r: column).toCube())
+            }
+        }
+        return tiles
+    }
+
+    /// Create grid of rectangular shape (whose edges are more or less vertical and horizontal)
     /// - parameters:
     ///     - orientation: See `OrientationEnumeration` options
     ///     - offsetLayout: See `OffsetLayoutEnumeration` options
     ///     - width: number of columns
     ///     - height: number of rows
-    static func createRectangleGrid (
+    static func createRectangleGrid(
         orientation: Orientation,
         offsetLayout: OffsetLayout,
         width: Int,
-        height: Int) throws -> Set<CubeCoordinates> {
+        height: Int
+    ) throws -> Set<CubeCoordinates> {
         guard width > 0, height > 0 else {
             throw InvalidArgumentsError(message: "Rectangle width and height must be greater than zero.")
         }
@@ -73,13 +98,13 @@ internal struct Generator {
         }
         return tiles
     }
-    
+
     /// Create grid of hexagonal shape
     /// - parameters:
     ///     - sideLength: side length of desired hexagonal shape (1 -> single tile, 2 -> 7 tiles, 3 -> 19 tiles...)
-    static func createHexagonGrid (
+    static func createHexagonGrid(
         sideLength: Int
-        ) throws -> Set<CubeCoordinates> {
+    ) throws -> Set<CubeCoordinates> {
         guard sideLength > 0 else {
             throw InvalidArgumentsError(message: "Hexagon side length must be greater than zero.")
         }
@@ -97,10 +122,10 @@ internal struct Generator {
     /// - parameters:
     ///     - orientation: See `OrientationEnumeration` options
     ///     - sideLength: size of a triangle side (result triangle is equilateral)
-    static func createTriangleGrid (
+    static func createTriangleGrid(
         orientation: Orientation,
         sideLength: Int
-        ) throws -> Set<CubeCoordinates> {
+    ) throws -> Set<CubeCoordinates> {
         guard sideLength > 0 else {
             throw InvalidArgumentsError(message: "Triangle side length must be greater than zero.")
         }

--- a/Tests/HexGridTests/GridGeneratorTests.swift
+++ b/Tests/HexGridTests/GridGeneratorTests.swift
@@ -141,15 +141,92 @@ class GridGeneratorTests: XCTestCase {
             hexSize: hexSize,
             origin: origin)
         XCTAssertEqual(result.cells.count, 0)
+
+        // test for invalid parallelogram
+        shape = GridShape.parallelogram(-3, 5)
+        result = HexGrid(
+            shape: shape,
+            orientation: orientation,
+            offsetLayout: offsetLayout,
+            hexSize: hexSize,
+            origin: origin)
+        XCTAssertEqual(result.cells.count, 0)
+
+        // test for invalid irregular hexagon
+        shape = GridShape.irregularHexagon(-3, 5)
+        result = HexGrid(
+            shape: shape,
+            orientation: orientation,
+            offsetLayout: offsetLayout,
+            hexSize: hexSize,
+            origin: origin)
+        XCTAssertEqual(result.cells.count, 0)
     }
-    
-    
+
+    /// Create parallelogram grids
+    func testCreateParallelogramGrids () throws {
+        var orientation = Orientation.pointyOnTop
+        var offsetLayout = OffsetLayout.even
+        let hexSize = HexSize(width: 10.0, height: 10.0)
+        let origin = Point(x: 0.0, y: 0.0)
+
+        var shape = GridShape.parallelogram(3, 4)
+        let gridPointy = HexGrid(
+            shape: shape,
+            orientation: orientation,
+            offsetLayout: offsetLayout,
+            hexSize: hexSize,
+            origin: origin)
+        XCTAssertEqual(gridPointy.cells.count, 12)
+
+        shape = GridShape.parallelogram(10, 20)
+        orientation = Orientation.flatOnTop
+        offsetLayout = OffsetLayout.even
+        let gridFlat = HexGrid(
+            shape: shape,
+            orientation: orientation,
+            offsetLayout: offsetLayout,
+            hexSize: hexSize,
+            origin: origin)
+        XCTAssertEqual(gridFlat.cells.count, 200)
+    }
+
+    /// Create irregular hexagon grids
+    func testCreateIrregularHexagonGrids () throws {
+        var orientation = Orientation.pointyOnTop
+        var offsetLayout = OffsetLayout.even
+        let hexSize = HexSize(width: 10.0, height: 10.0)
+        let origin = Point(x: 0.0, y: 0.0)
+
+        var shape = GridShape.irregularHexagon(3, 4)
+        let gridPointy = HexGrid(
+            shape: shape,
+            orientation: orientation,
+            offsetLayout: offsetLayout,
+            hexSize: hexSize,
+            origin: origin)
+        XCTAssertEqual(gridPointy.cells.count, 27)
+
+        shape = GridShape.irregularHexagon(2, 3)
+        orientation = Orientation.flatOnTop
+        offsetLayout = OffsetLayout.even
+        let gridFlat = HexGrid(
+            shape: shape,
+            orientation: orientation,
+            offsetLayout: offsetLayout,
+            hexSize: hexSize,
+            origin: origin)
+        XCTAssertEqual(gridFlat.cells.count, 12)
+    }
+
     
     static var allTests = [
         ("Create rectangular grids", testCreateRectangleGrid),
         ("Create hexagonal grid", testCreateHexagonGrid),
         ("Create triangular grid", testCreateTriangleGrid),
-        ("Create invalid shape grid", testCreateInvalidShapeGrid)
+        ("Create invalid shape grid", testCreateInvalidShapeGrid),
+        ("Create parallelogram shape grid", testCreateParallelogramGrids),
+        ("Create irregular hexagon shape grid", testCreateIrregularHexagonGrids),
         ]
     
 }


### PR DESCRIPTION
This PR adds a [parallelogram](https://www.redblobgames.com/grids/hexagons/implementation.html#shape-parallelogram) generator, as well as an irregular hexagon grid generator. The irregular hexagon algorithm took a while to work out, but I think I'm happy with it now. (Definitely open to improvement!)

You can see this in action by checking out the `feature-more-generators` branch of `mgrider/SKHexGrid` and then pointing the hex-grid package at this branch, but I've also attached a screenshot of a 4x7 hexagon grid.

![Simulator Screen Shot - iPad (10th generation) - 2023-02-12 at 17 44 30](https://user-images.githubusercontent.com/604867/218344554-cb54c5c4-3ed0-4ebf-8cc2-9f9aa0f55a13.png)
