### PR TITLE
cleaned up the readme a bit more, added the elongatedHexagon generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,25 @@
     
     API might change without further notice until first major release 1.x.x.
 
-HexGrid library provides easy and intuitive way of working with hexagonal grids. Under the hood it handles all the math so you can focus on more important stuff.
+The `HexGrid` library provides an easy and intuitive way of working with hexagonal grids. Under the hood it handles all the math so you can focus on more important stuff.
 
-- Support any gird shape, including irregular one or grid with holes.
+- Support for grids of any shape, including irregular shapes, or grids with holes in them.
 
-The library is meant for generic backend use. Therefore it doesn't not offer any UI or rendering stuff. However, it provides calculations needed for grid rendering.
+The library is meant for generic backend use. Therefore it doesn't perform any UI or rendering. However, it provides the calculations that will be needed for rendering.
 
 ## Features
 
-- [x] Create or generate a grid with hexagonal cells.  
-- [x] Various coordinate systems (cube, axial, offset).  
-- [x] Rotation, Manhattan distance, linear interpolation.  
-- [x] Get Neighbors or diagonal neighbors.  
-- [x] Get Line (get all hexes making a line from A to B).  
-- [x] Get Ring (get all hexes making a ring from an origin coordinates in specified radius).  
-- [x] Get Filled Ring (get all hexes making a filled ring from an origin coordinates in specified radius).  
-- [x] Find reachable hexes within `n` steps (Breath First Search).  
+- [x] Create or generate a grid of hexagonal cells.
+- [x] Various coordinate systems (cube, axial, offset), and conversion between them.
+- [x] Rotation, Manhattan distance, linear interpolation.
+- [x] Get Neighbors or diagonal neighbors.
+- [x] Get Line (get all hexes making a line from A to B).
+- [x] Get Ring (get all hexes making a ring from an origin coordinates in specified radius).
+- [x] Get Filled Ring (get all hexes making a filled ring from an origin coordinates in specified radius).
+- [x] Find reachable hexes within `n` steps (Breath First Search).
 - [x] Find the shortest path from A to B (optimized A* search algorithm).
 - [x] FieldOfView algorithm (`ShadowCasting` designed for hexagonal grids).
-- [x] Hexagon rendering related stuff (e.g. polygon corners).  
+- [x] Hexagon rendering related functions (e.g. get polygon corners).
 - [x] Code inline documentation (quick help).
 - [x] Solid unit tests coverage.
 - [x] Automated documentation generator (SwiftDoc + GitHub Actions -> hosted on repo GitHub Pages).
@@ -90,7 +90,7 @@ Grids can be initialized either with a set of cell coordinates, or HexGrid can g
 
 #### Standard shape grids
 
-Example:
+For example:
 
 ```swift
 ...
@@ -101,6 +101,8 @@ var grid = HexGrid(shape: GridShape.rectangle(8, 12))
 // or triangular shape
 var grid = HexGrid(shape: GridShape.triangle(6))
 ```
+
+See the section on `GridShape` below for more details, and a full list of the available grid shapes.
 
 #### Custom grids
 
@@ -384,7 +386,8 @@ Options:
 - `rectangle(Int, Int)` - Associated values are column width and row height of the generated grid. Sides of the grid will be essentially parallel to the edges of the screen.
 - `parallelogram(Int, Int)` - Associated values are both side-lengths.
 - `hexagon(Int)` - This generates a regular hexagon shaped grid, with all sides the length of the associated value.
-- `irregularHexagon(Int, Int)` - This is used to generate a grid shaped like a hexagon where every other side is the length of the associated values.
+- `elongatedHexagon(Int, Int)` - This is used to generate a grid shaped like a regular hexagon that has been stretched or elongated in one dimension. The associated values are side lengths.
+- `irregularHexagon(Int, Int)` - This is used to generate a grid shaped like a hexagon where every other side is the length of the two associated values.
 - `triangle(Int)` - Generates an equilateral triangle with all sides the length of the associated value.
 
 ##### Rotation

--- a/Sources/HexGrid/Enumerations/GridShapeEnumeration.swift
+++ b/Sources/HexGrid/Enumerations/GridShapeEnumeration.swift
@@ -7,6 +7,10 @@ public enum GridShape {
     /// Hexagonal `GridShape`. Stored property corresponds to side-length.
     case hexagon(Int)
 
+    /// Elongated hexagon `GridShape`. Stored properties correspond to side-lengths.
+    /// Note that if the side lengths are the same, this falls back to the default hexagon shape.
+    case elongatedHexagon(Int, Int)
+
     /// Irregular hexagon `GridShape`. Stored properties correspond to side-lengths.
     /// Note that if the side lengths are the same, this falls back to the default hexagon shape.
     case irregularHexagon(Int, Int)

--- a/Tests/HexGridTests/GridGeneratorTests.swift
+++ b/Tests/HexGridTests/GridGeneratorTests.swift
@@ -191,6 +191,45 @@ class GridGeneratorTests: XCTestCase {
         XCTAssertEqual(gridFlat.cells.count, 200)
     }
 
+    /// Create extended hexagon grids
+    func testCreateElongatedHexagonGrids () throws {
+
+        var shape = GridShape.elongatedHexagon(3, 4)
+        var grid = HexGrid(
+            shape: shape,
+            orientation: .pointyOnTop)
+        XCTAssertEqual(grid.cells.count, 30)
+
+        // flat
+        grid = HexGrid(
+            shape: shape,
+            orientation: .flatOnTop)
+        XCTAssertEqual(grid.cells.count, 24)
+
+        shape = GridShape.elongatedHexagon(2, 3)
+        grid = HexGrid(
+            shape: shape,
+            orientation: .pointyOnTop)
+        XCTAssertEqual(grid.cells.count, 14)
+
+        grid = HexGrid(
+            shape: shape,
+            orientation: .flatOnTop)
+        XCTAssertEqual(grid.cells.count, 10)
+
+        shape = GridShape.elongatedHexagon(7, 3)
+        grid = HexGrid(
+            shape: shape,
+            orientation: .pointyOnTop)
+        XCTAssertEqual(grid.cells.count, 39)
+
+        shape = GridShape.elongatedHexagon(3, 7)
+        grid = HexGrid(
+            shape: shape,
+            orientation: .flatOnTop)
+        XCTAssertEqual(grid.cells.count, 39)
+    }
+
     /// Create irregular hexagon grids
     func testCreateIrregularHexagonGrids () throws {
         var orientation = Orientation.pointyOnTop
@@ -219,14 +258,14 @@ class GridGeneratorTests: XCTestCase {
         XCTAssertEqual(gridFlat.cells.count, 12)
     }
 
-    
     static var allTests = [
         ("Create rectangular grids", testCreateRectangleGrid),
         ("Create hexagonal grid", testCreateHexagonGrid),
         ("Create triangular grid", testCreateTriangleGrid),
         ("Create invalid shape grid", testCreateInvalidShapeGrid),
         ("Create parallelogram shape grid", testCreateParallelogramGrids),
+        ("Create elongated hexagon shape grid", testCreateElongatedHexagonGrids),
         ("Create irregular hexagon shape grid", testCreateIrregularHexagonGrids),
-        ]
-    
+    ]
+
 }


### PR DESCRIPTION
Hope the readme improvements are okay. I just tried to clean up the english a bit here and there. 

The elongated hexagons are different from the irregular hexagons. You can think of them more as a stretched out regular hexagon. For instance:

<img width="476" alt="Screenshot 2023-02-22 at 2 39 28 PM" src="https://user-images.githubusercontent.com/604867/220753737-90461906-0a8d-4df7-bd24-367c8fdd04ed.png">
